### PR TITLE
ActionButtonコンポーネントを追加

### DIFF
--- a/components/ActionButton.vue
+++ b/components/ActionButton.vue
@@ -1,0 +1,55 @@
+<template>
+  <button
+    :class="`actionButton actionButton-${theme}`"
+    :style="{ fontSize: fontSizeMap.get(size) }"
+    @click="$emit('click')"
+  >
+    {{ text }}
+  </button>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop } from 'nuxt-property-decorator'
+
+type ThemeType = 'primary' | 'error'
+type SizeType = 'L' | 'M' | 'S'
+type FontSizeType = string
+
+@Component
+export default class ActionButton extends Vue {
+  fontSizeMap: Map<SizeType, FontSizeType> = new Map([
+    ['L', '24px'],
+    ['M', '16px'],
+    ['S', '12px'],
+  ])
+
+  @Prop({ default: 'primary' })
+  theme!: ThemeType
+
+  @Prop({ default: '' })
+  text!: string
+
+  @Prop({ default: 'L' })
+  size!: SizeType
+}
+</script>
+
+<style lang="scss" scoped>
+.actionButton {
+  font-weight: bold;
+  padding: 0.8em 3em;
+  border-radius: 0.5em;
+  border: none;
+  color: $white;
+  &-primary {
+    background-color: $primary;
+  }
+  &-error {
+    background-color: $error;
+  }
+  &:focus {
+    opacity: 0.7;
+    outline: dotted $gray-2 1px;
+  }
+}
+</style>

--- a/components/PageHeader.vue
+++ b/components/PageHeader.vue
@@ -4,7 +4,7 @@
       {{ text }}
     </h2>
     <div v-if="isLoggedIn" class="account">
-      <button>ログアウト</button>
+      <ActionButton theme="primary" size="S" text="ログアウト" />
       <div class="accountInfo">
         <span>XX保健所</span><br />
         <span>管理者00001</span>
@@ -15,8 +15,12 @@
 
 <script lang="ts">
 import Vue from 'vue'
+import ActionButton from '@/components/ActionButton.vue'
 
 export default Vue.extend({
+  components: {
+    ActionButton,
+  },
   props: {
     text: {
       type: String,

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@nuxt/typescript-runtime": "^2.0.0",
     "core-js": "^3.8.1",
     "nuxt": "^2.14.12",
+    "nuxt-property-decorator": "^2.8.8",
     "nuxt-svg-loader": "^1.2.0"
   },
   "devDependencies": {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <PageHeader text="ログイン" />
+    <PageHeader text="患者データ一覧" />
   </div>
 </template>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7149,6 +7149,16 @@ number-is-nan@^1.0.0:
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
   integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
 
+nuxt-property-decorator@^2.8.8:
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/nuxt-property-decorator/-/nuxt-property-decorator-2.8.8.tgz#a383fdaa9a94f79937a1add0218a6736ff1a8f25"
+  integrity sha512-JdSbzZmiHk47ZSDZ1sF2iYTr13fVKUrtqj+e/APtRjkKhFNpmNpjlWycjKsDE+UxJQtDcNrmGKYWhwaP6hOXBg==
+  dependencies:
+    vue-class-component "^7.2.6"
+    vue-property-decorator "^9.0.0"
+    vuex-class "^0.3.2"
+    vuex-module-decorators "^1.0.1"
+
 nuxt-svg-loader@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/nuxt-svg-loader/-/nuxt-svg-loader-1.2.0.tgz#1f2448d5170168b12c4275cd7774a79eee0132ae"
@@ -10523,6 +10533,11 @@ vm-browserify@^1.0.1:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
 
+vue-class-component@^7.2.6:
+  version "7.2.6"
+  resolved "https://registry.yarnpkg.com/vue-class-component/-/vue-class-component-7.2.6.tgz#8471e037b8e4762f5a464686e19e5afc708502e4"
+  integrity sha512-+eaQXVrAm/LldalI272PpDe3+i4mPis0ORiMYxF6Ae4hyuCh15W8Idet7wPUEs4N4YptgFHGys4UrgNQOMyO6w==
+
 vue-client-only@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/vue-client-only/-/vue-client-only-2.0.0.tgz#ddad8d675ee02c761a14229f0e440e219de1da1c"
@@ -10568,6 +10583,11 @@ vue-no-ssr@^1.1.1:
   resolved "https://registry.yarnpkg.com/vue-no-ssr/-/vue-no-ssr-1.1.1.tgz#875f3be6fb0ae41568a837f3ac1a80eaa137b998"
   integrity sha512-ZMjqRpWabMPqPc7gIrG0Nw6vRf1+itwf0Itft7LbMXs2g3Zs/NFmevjZGN1x7K3Q95GmIjWbQZTVerxiBxI+0g==
 
+vue-property-decorator@^9.0.0:
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/vue-property-decorator/-/vue-property-decorator-9.1.2.tgz#266a2eac61ba6527e2e68a6933cfb98fddab5457"
+  integrity sha512-xYA8MkZynPBGd/w5QFJ2d/NM0z/YeegMqYTphy7NJQXbZcuU6FC6AOdUAcy4SXP+YnkerC6AfH+ldg7PDk9ESQ==
+
 vue-router@^3.4.9:
   version "3.4.9"
   resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-3.4.9.tgz#c016f42030ae2932f14e4748b39a1d9a0e250e66"
@@ -10612,6 +10632,16 @@ vue@^2.6.12:
   version "2.6.12"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.12.tgz#f5ebd4fa6bd2869403e29a896aed4904456c9123"
   integrity sha512-uhmLFETqPPNyuLLbsKz6ioJ4q7AZHzD8ZVFNATNyICSZouqP2Sz0rotWQC8UNBF6VGSCs5abnKJoStA6JbCbfg==
+
+vuex-class@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/vuex-class/-/vuex-class-0.3.2.tgz#c7e96a076c1682137d4d23a8dcfdc63f220e17a8"
+  integrity sha512-m0w7/FMsNcwJgunJeM+wcNaHzK2KX1K1rw2WUQf7Q16ndXHo7pflRyOV/E8795JO/7fstyjH3EgqBI4h4n4qXQ==
+
+vuex-module-decorators@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/vuex-module-decorators/-/vuex-module-decorators-1.0.1.tgz#d34dafb5428a3636f1c26d3d014c15fc9659ccd0"
+  integrity sha512-FLWZsXV5XAtl/bcKUyQFpnSBtpc3wK/7zSdy9oKbyp71mZd4ut5y2zSd219wWW9OG7WUOlVwac4rXFFDVnq7ug==
 
 vuex@^3.6.0:
   version "3.6.0"


### PR DESCRIPTION
close #12 

- ボタンコンポーネントを作成しました。
- 見た目は[figmaの共通コンポーネント集](https://www.figma.com/file/29X7k8bKfFlWS6Md5BhrME/%E9%81%A0%E9%9A%94%E7%99%82%E9%A4%8A%E8%80%85%E3%83%A2%E3%83%8B%E3%82%BF%E3%83%AA%E3%83%B3%E3%82%B0%E3%82%B7%E3%82%B9%E3%83%86%E3%83%A0?node-id=18%3A1432)に寄せました。
- `theme` と `size` のpropsはenum型にしました。
- クリックした時のスタイルは要検討です。

![スクリーンショット 2020-12-30 19 45 38](https://user-images.githubusercontent.com/14883063/103346631-e4ae8a00-4ad7-11eb-93d0-75a89019b0bd.png)
