### PR TITLE
患者登録＆登録完了ページを作成

### DIFF
--- a/components/ActionButton.vue
+++ b/components/ActionButton.vue
@@ -41,6 +41,7 @@ export default class ActionButton extends Vue {
   border-radius: 0.5em;
   border: none;
   color: $white;
+  cursor: pointer;
   &-primary {
     background-color: $primary;
   }

--- a/components/InputField.vue
+++ b/components/InputField.vue
@@ -4,6 +4,7 @@
     <input
       class="inputField"
       :type="type"
+      :name="name"
       :value="value"
       @input="$emit('input', $event.target.value)"
     />
@@ -24,6 +25,10 @@ export default Vue.extend({
       default: '',
     },
     label: {
+      type: String,
+      default: '',
+    },
+    name: {
       type: String,
       default: '',
     },

--- a/components/RegistrationFlow.vue
+++ b/components/RegistrationFlow.vue
@@ -1,0 +1,55 @@
+<template>
+  <section>
+    <h3>ID発行と通知の流れ</h3>
+    <ul class="registrationFlowList">
+      <li :class="['registrationFlowItem', { active: step === 1 }]">
+        <p class="registrationFlowText">ID発行</p>
+      </li>
+      <li :class="['registrationFlowItem', { active: step === 2 }]">
+        <p class="registrationFlowText alignLeft">
+          発行されたIDとパスワード、症状入力用URLを患者に伝える
+        </p>
+      </li>
+    </ul>
+  </section>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+
+export default Vue.extend({
+  props: {
+    step: {
+      type: Number,
+      default: 0,
+    },
+  },
+})
+</script>
+
+<style lang="scss" scoped>
+.registrationFlowList {
+  display: flex;
+  list-style: none;
+  padding: 0;
+}
+.registrationFlowItem {
+  display: flex;
+  align-items: center;
+  width: 180px;
+  padding: 20px;
+  margin-right: 16px;
+  background-color: $gray-1;
+  &.active {
+    background-color: $notice;
+  }
+}
+.registrationFlowText {
+  flex: 1 1 auto;
+  text-align: center;
+  margin: 0;
+  &.alignLeft {
+    text-align: left;
+  }
+}
+</style>

--- a/pages/register.vue
+++ b/pages/register.vue
@@ -5,6 +5,7 @@
     <div class="inputContainer">
       <InputField
         label="ニックネーム（任意）"
+        name="memo"
         :value="inputMemo"
         @input="inputMemo = $event"
       />
@@ -13,6 +14,7 @@
     <div class="inputContainer">
       <InputField
         label="携帯電話番号（任意）"
+        name="mobileTel"
         :value="inputMobileTel"
         @input="inputMobileTel = $event"
       />

--- a/pages/register.vue
+++ b/pages/register.vue
@@ -1,0 +1,64 @@
+<template>
+  <div>
+    <PageHeader text="患者登録" :is-logged-in="true" />
+    <p>患者のIDを新規で発行します。</p>
+    <div class="inputContainer">
+      <InputField
+        label="ニックネーム（任意）"
+        :value="inputMemo"
+        @input="inputMemo = $event"
+      />
+      <p>患者には通知されない、識別用の任意のメモです。</p>
+    </div>
+    <div class="inputContainer">
+      <InputField
+        label="携帯電話番号（任意）"
+        :value="inputMobileTel"
+        @input="inputMobileTel = $event"
+      />
+      <p>
+        SMS（ショートメッセージ）で、ID/PWDを通知します。<br />
+        患者が普段使うスマートフォンの番号を入力してください。
+      </p>
+    </div>
+    <ActionButton theme="primary" size="M" text="患者IDを発行する" />
+    <div class="flow">
+      <RegistrationFlow :step="1" />
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import PageHeader from '@/components/PageHeader.vue'
+import InputField from '@/components/InputField.vue'
+import ActionButton from '@/components/ActionButton.vue'
+import RegistrationFlow from '@/components/RegistrationFlow.vue'
+
+export default Vue.extend({
+  name: 'Register',
+  components: {
+    PageHeader,
+    InputField,
+    ActionButton,
+    RegistrationFlow,
+  },
+  data() {
+    return {
+      inputMemo: '',
+      inputMobileTel: '',
+    }
+  },
+})
+</script>
+
+<style lang="scss" scoped>
+.inputContainer {
+  width: 100%;
+  max-width: 600px;
+  margin: 30px 0;
+}
+.flow {
+  margin-top: 36px;
+}
+</style>

--- a/pages/registered.vue
+++ b/pages/registered.vue
@@ -1,0 +1,71 @@
+<template>
+  <div>
+    <PageHeader text="患者登録完了" :is-logged-in="true" />
+    <p>患者のIDを発行しました。</p>
+    <dl class="registrationList">
+      <dt class="registrationTitle">患者ID</dt>
+      <dd class="registrationItem">03Xdt</dd>
+      <dt class="registrationTitle">パスワード</dt>
+      <dd class="registrationItem">xm4HY</dd>
+      <dt class="registrationTitle">携帯電話番号</dt>
+      <dd class="registrationItem">
+        <span>090-0000-0000</span>
+        <p class="subText">こちらの携帯番号に利用方法を送信済みです。</p>
+      </dd>
+      <dt class="registrationTitle">症状入力サイトURL</dt>
+      <dd class="registrationItem">https://xxxxxx.jp</dd>
+      <dt class="registrationTitle">ニックネーム</dt>
+      <dd class="registrationItem">Sさん</dd>
+    </dl>
+    <ActionButton theme="primary" size="M" text="別のIDを発行する" />
+    <div class="flow">
+      <RegistrationFlow :step="2" />
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import PageHeader from '@/components/PageHeader.vue'
+import ActionButton from '@/components/ActionButton.vue'
+import RegistrationFlow from '@/components/RegistrationFlow.vue'
+
+export default Vue.extend({
+  name: 'Registered',
+  components: {
+    PageHeader,
+    ActionButton,
+    RegistrationFlow,
+  },
+})
+</script>
+
+<style lang="scss" scoped>
+.registrationList {
+  font-size: 24px;
+  font-weight: bold;
+  &::after {
+    content: '';
+    display: block;
+    clear: both;
+  }
+}
+.registrationTitle {
+  clear: both;
+  float: left;
+  width: 12em;
+  margin-bottom: 12px;
+}
+.registrationItem {
+  float: left;
+  margin: 0 0 12px;
+  .subText {
+    font-size: 18px;
+    font-weight: normal;
+    margin: 0;
+  }
+}
+.flow {
+  margin-top: 36px;
+}
+</style>


### PR DESCRIPTION
close #21 

- 患者登録ページ `pages/register.vue` と登録完了ページ `pages/registerd` を作成しました。
- ロジックは未実装です。
- データはベタ書きしています。

![スクリーンショット 2021-01-01 14 56 29](https://user-images.githubusercontent.com/14883063/103434264-3410c980-4c42-11eb-976b-d2ae1df758d9.png)

![スクリーンショット 2021-01-01 14 56 41](https://user-images.githubusercontent.com/14883063/103434267-40952200-4c42-11eb-8eaf-5bde28bae874.png)
