### PR TITLE
患者一覧頁のグラフの調整を行った

### DIFF
--- a/components/PatientOverviewGraph.vue
+++ b/components/PatientOverviewGraph.vue
@@ -47,13 +47,12 @@ export default {
           curve: 'smooth',
           width: 2,
         },
-        tooltip: {
-          enabled: true,
-        },
         xaxis: {
           type: 'datetime',
           labels: {
             show: true,
+            rotate: -30,
+            rotateAlways: true,
             formatter: (val) => {
               return dayjs(val).format('MM/DD')
             },
@@ -63,6 +62,16 @@ export default {
           },
           axisTicks: {
             show: true,
+          },
+          tooltip: {
+            enabled: false,
+          },
+        },
+        tooltip: {
+          x: {
+            formatter: (val) => {
+              return dayjs(val).format('MM/DD HH:mm')
+            },
           },
         },
         yaxis: [


### PR DESCRIPTION
# 作業内容
- tooltip内の時刻表記を時・分までにした
- x軸のラベルをrotateしたことによって、右端のラベルを表示できるようにした
![スクリーンショット 2021-03-08 18 46 23](https://user-images.githubusercontent.com/5211989/110305043-9ec5f300-803f-11eb-8122-b98b07e042ce.png)

# Related
- #8 
- #164 
