### PR TITLE
font-familyを指定

### DIFF
--- a/assets/global.scss
+++ b/assets/global.scss
@@ -1,4 +1,5 @@
 :root {
+  font-family: "Hiragino Sans", "Meiryo", "Source Han Sans", "Noto Sans CJK JP", "Yu Gothic", sans-serif;
   color: #252733;
 }
 
@@ -26,4 +27,8 @@ ul {
 
 a {
   color: $primary;
+}
+
+h1,h2,h3 {
+  font-weight: 600;
 }

--- a/components/ActionButton.vue
+++ b/components/ActionButton.vue
@@ -70,7 +70,7 @@ export default class ActionButton extends Vue {
 .actionButton {
   display: inline-block;
   width: 100%;
-  font-weight: bold;
+  font-weight: 600;
   padding: 0.8em 1em;
   border-radius: 0.5em;
   border: none;

--- a/components/PatientOverview.vue
+++ b/components/PatientOverview.vue
@@ -181,7 +181,7 @@ export default class PatientOverview extends Vue {
 }
 .spo2 {
   font-size: 32px;
-  font-weight: bold;
+  font-weight: 600;
 }
 .statusItem {
   width: 100%;

--- a/components/PatientRegistered.vue
+++ b/components/PatientRegistered.vue
@@ -72,7 +72,7 @@ export default class PatientRegistered extends Vue {
   margin: 24px 0 8px;
 }
 .registrationItem {
-  font-weight: 700;
+  font-weight: 600;
   margin-left: 0;
 }
 .registrationMessage {

--- a/components/Sidebar.vue
+++ b/components/Sidebar.vue
@@ -165,7 +165,7 @@ export default class Sidebar extends Vue {
   color: $gray-2;
   text-decoration: none;
   &.nuxt-link-exact-active {
-    font-weight: bold;
+    font-weight: 600;
 
     &:link,
     &:hover,

--- a/components/SymptomsStatus.vue
+++ b/components/SymptomsStatus.vue
@@ -24,6 +24,6 @@ export default Vue.extend({
 <style lang="scss" scoped>
 .symptomsText {
   font-size: 14px;
-  font-weight: bold;
+  font-weight: 600;
 }
 </style>

--- a/components/SymptomsStatusText.vue
+++ b/components/SymptomsStatusText.vue
@@ -23,7 +23,7 @@ export default Vue.extend({
 
 <style lang="scss" scoped>
 .statusText {
-  font-weight: bold;
+  font-weight: 600;
   color: $gray-2;
   &.active {
     color: $notice;

--- a/pages/center/_centerId/index.vue
+++ b/pages/center/_centerId/index.vue
@@ -265,6 +265,9 @@ export default class CenterId extends Vue {
   padding: 8px 0;
   text-align: left;
   text-indent: 16px;
+  th {
+    font-weight: 600;
+  }
 }
 .overviewLabel {
   font-size: 12px;

--- a/pages/center/_centerId/patient/_patientId.vue
+++ b/pages/center/_centerId/patient/_patientId.vue
@@ -167,7 +167,7 @@ export default class PatientId extends Vue {
 }
 .patentId {
   font-size: 20px;
-  font-weight: bold;
+  font-weight: 600;
 }
 .icon {
   display: inline-block;
@@ -204,13 +204,13 @@ export default class PatientId extends Vue {
 }
 .patientSummaryTitle {
   font-size: 16px;
-  font-weight: bold;
+  font-weight: 600;
   color: $gray-3;
   padding-top: 24px;
 }
 .patientSummaryItem {
   font-size: 24px;
-  font-weight: bold;
+  font-weight: 600;
   margin: 0;
   padding: 16px;
   border-bottom: 1px solid $gray-3;


### PR DESCRIPTION
font-familyを指定したことによるboldの激太りを避けるため、`font-weight: bold;` を `font-weight: 600;` に修正。