### PR TITLE
グローバルの閾値（SpO2・体温・脈拍）を設定

### DIFF
--- a/components/PatientOverview.vue
+++ b/components/PatientOverview.vue
@@ -135,10 +135,6 @@ import ActionButton from '@/components/ActionButton.vue'
 })
 export default class PatientOverview extends Vue {
   outdatedDay = 1
-  SpO2Threshold = 95
-  bodyTemperatureThreshold = 38.5
-  pulseThresholdUnder = 60
-  pulseThresholdUpper = 100
   defaultStatus: Status | undefined = {
     statusId: '',
     patientId: '',
@@ -174,19 +170,21 @@ export default class PatientOverview extends Vue {
   }
 
   get isAlertedSpO2(): boolean {
-    return this.lastStatus ? this.lastStatus?.SpO2 <= this.SpO2Threshold : false
+    return this.lastStatus
+      ? this.lastStatus?.SpO2 <= this.$threshold.SpO2
+      : false
   }
 
   get isAlertedBodyTemperature(): boolean {
     return this.lastStatus
-      ? this.lastStatus?.body_temperature >= this.bodyTemperatureThreshold
+      ? this.lastStatus?.body_temperature >= this.$threshold.bodyTemperature
       : false
   }
 
   get isAlertedPulse(): boolean {
     return this.lastStatus
-      ? this.lastStatus?.pulse <= this.pulseThresholdUnder ||
-          this.lastStatus.pulse >= this.pulseThresholdUpper
+      ? this.lastStatus?.pulse <= this.$threshold.pulseUnder ||
+          this.lastStatus.pulse >= this.$threshold.pulseUpper
       : false
   }
 

--- a/components/SymptomsHistory.vue
+++ b/components/SymptomsHistory.vue
@@ -18,9 +18,22 @@
           class="symptomsHistoryRow"
         >
           <td>{{ getDate(item.created) }}</td>
-          <td class="alignCenter spo2">{{ item.SpO2 }}</td>
-          <td class="alignCenter">{{ item.body_temperature.toFixed(1) }}</td>
-          <td class="alignCenter">{{ item.pulse }}</td>
+          <td
+            :class="['alignCenter spo2', { alerted: isAlertedSpO2(item.SpO2) }]"
+          >
+            {{ item.SpO2 }}
+          </td>
+          <td
+            :class="[
+              'alignCenter',
+              { alerted: isAlertedBodyTemperature(item.body_temperature) },
+            ]"
+          >
+            {{ item.body_temperature.toFixed(1) }}
+          </td>
+          <td :class="['alignCenter', { alerted: isAlertedPulse(item.pulse) }]">
+            {{ item.pulse }}
+          </td>
           <td>
             <div class="symptoms">
               <SymptomsStatusText
@@ -53,27 +66,39 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
+import { Component, Prop, Vue } from 'vue-property-decorator'
 import dayjs from 'dayjs'
 import { Status } from '@/types/component-interfaces/status'
 import SymptomsStatusText from '@/components/SymptomsStatusText.vue'
 
-export default Vue.extend({
+@Component({
   components: {
     SymptomsStatusText,
   },
-  props: {
-    statuses: {
-      type: Array as () => Status[],
-      default: [],
-    },
-  },
-  methods: {
-    getDate(date: string): string {
-      return dayjs(date).format('M/D (ddd) HH:mm')
-    },
-  },
 })
+export default class SymptomsHistory extends Vue {
+  @Prop({ default: [] })
+  statuses!: Status[]
+
+  isAlertedSpO2(value: number): boolean {
+    return value ? value <= this.$threshold.SpO2 : false
+  }
+
+  isAlertedBodyTemperature(value: number): boolean {
+    return value ? value >= this.$threshold.bodyTemperature : false
+  }
+
+  isAlertedPulse(value: number): boolean {
+    return value
+      ? value <= this.$threshold.pulseUnder ||
+          value >= this.$threshold.pulseUpper
+      : false
+  }
+
+  getDate(date: string): string {
+    return dayjs(date).format('M/D (ddd) HH:mm')
+  }
+}
 </script>
 
 <style lang="scss" scoped>
@@ -116,5 +141,8 @@ export default Vue.extend({
 .symptoms {
   color: $gray-2;
   padding: 0 1em;
+}
+.alerted {
+  color: $error;
 }
 </style>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -49,7 +49,14 @@ export default {
       src: '@/plugins/vue-apexchart.ts',
       ssr: false,
     },
-    '@/plugins/axios',
+    {
+      src: '@/plugins/axios',
+      ssr: false,
+    },
+    {
+      src: '@/plugins/threshold',
+      ssr: false,
+    },
   ],
 
   loading: { color: '#FF8000' },

--- a/plugins/threshold.ts
+++ b/plugins/threshold.ts
@@ -1,0 +1,26 @@
+import { Plugin } from '@nuxt/types'
+
+interface Threshold {
+  SpO2: number
+  bodyTemperature: number
+  pulseUnder: number
+  pulseUpper: number
+}
+
+const plugin: Plugin = function (_, inject) {
+  const threshold: Threshold = {
+    SpO2: 90,
+    bodyTemperature: 37.5,
+    pulseUnder: 60,
+    pulseUpper: 100,
+  }
+
+  inject('threshold', threshold)
+}
+export default plugin
+
+declare module 'vue/types/vue' {
+  interface Vue {
+    $threshold: Threshold
+  }
+}


### PR DESCRIPTION
close #241 

- 患者一覧と患者詳細で閾値をみてフォントカラー（またはアイコン）を赤にするようにしました
- nuxt.config.jsでのpluginの追加時に `ssr: false` を指定するようにしました
