### PR TITLE
CLIENT_URLのデフォルトにハッシュを追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
-CLIENT_URL=http://localhost:8080
+CLIENT_URL=http://localhost:8080/#
 API_URL=https://api.rms.stopcovid19.jp/stg/api/nurse/

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -105,7 +105,7 @@ export default {
   },
 
   publicRuntimeConfig: {
-    clientUrl: process.env.CLIENT_URL || 'http://localhost:8080',
+    clientUrl: process.env.CLIENT_URL || 'http://localhost:8080/#',
     axios: {
       baseURL:
         process.env.API_URL || 'https://api.rms.stopcovid19.jp/stg/api/nurse/',


### PR DESCRIPTION
https://github.com/codeforjapan/remote-patient-monitoring-client/issues/176

いまのところ、clientのrouterはhashモードで動いているので、dashboardのenvの記述も変更しました。

TODO: 
- デプロイ時のenvも同様に要修正です。