### PR TITLE
体調フリー入力のヘッダーテキストを変更

### DIFF
--- a/components/SymptomsHistory.vue
+++ b/components/SymptomsHistory.vue
@@ -8,7 +8,7 @@
           <th>体温</th>
           <th>脈拍</th>
           <th class="alignLeft" style="padding-left: 20px">症状</th>
-          <th class="alignLeft">症状</th>
+          <th class="alignLeft">その他の体調の変化</th>
           <th></th>
         </tr>
       </thead>

--- a/pages/center/_centerId/patient/_patientId.vue
+++ b/pages/center/_centerId/patient/_patientId.vue
@@ -473,7 +473,7 @@ export default class PatientId extends Vue {
           息苦しさ: item.symptom?.suffocation ? 1 : 0,
           頭痛: item.symptom?.headache ? 1 : 0,
           のど痛み: item.symptom?.sore_throat ? 1 : 0,
-          症状備考: item.symptom?.remarks,
+          その他の体調の変化: item.symptom?.remarks,
         }
       })
       const csv = Papa.unparse(data, {


### PR DESCRIPTION
「その他の体調の変化」に変更、クライアント側を合わせます。