### PR TITLE
患者一覧のfetchのintervalを５分（300000ms）に修正

### DIFF
--- a/pages/center/_centerId/index.vue
+++ b/pages/center/_centerId/index.vue
@@ -107,7 +107,7 @@ export default class CenterId extends Vue {
     this.checkAndFetchPatients()
     this.timer = setInterval(() => {
       this.checkAndFetchPatients()
-    }, 30000)
+    }, 300000)
   }
 
   beforeDestroy() {


### PR DESCRIPTION
５分のつもりだったのですが、0が一つ足りなかったみたいです。